### PR TITLE
makes the EventStoreDb metrics source public

### DIFF
--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -1,4 +1,4 @@
-mod app;
-mod sources;
+pub mod app;
+pub mod sources;
 
 pub use app::run;

--- a/src/vector/sources/eventstoredb/metrics.rs
+++ b/src/vector/sources/eventstoredb/metrics.rs
@@ -11,7 +11,7 @@ use vector::{
 };
 
 #[derive(Deserialize, Serialize, Clone, Debug, Default)]
-struct EventStoreDbConfig {
+pub struct EventStoreDbConfig {
     #[serde(default = "default_endpoint")]
     endpoint: String,
     #[serde(default = "default_scrape_interval_secs")]
@@ -54,7 +54,7 @@ impl SourceConfig for EventStoreDbConfig {
     }
 }
 
-fn eventstoredb(
+pub fn eventstoredb(
     endpoint: &str,
     interval: u64,
     namespace: Option<String>,


### PR DESCRIPTION
This allows the EventStoreDb metrics code to be accessed as a library