### PR TITLE
Implement Disk Queue Length source.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -718,7 +718,7 @@ dependencies = [
 [[package]]
 name = "codec"
 version = "0.1.0"
-source = "git+https://github.com/timberio/vector.git#01ea5d1db9e35aa951059cbcac8d172f5d67acd3"
+source = "git+https://github.com/timberio/vector.git?rev=01ea5d1db9e35aa951059cbcac8d172f5d67acd3#01ea5d1db9e35aa951059cbcac8d172f5d67acd3"
 dependencies = [
  "bytes 1.0.1",
  "tokio-util",
@@ -1060,7 +1060,7 @@ dependencies = [
 [[package]]
 name = "derive_is_enum_variant"
 version = "1.0.0"
-source = "git+https://github.com/timberio/vector.git#01ea5d1db9e35aa951059cbcac8d172f5d67acd3"
+source = "git+https://github.com/timberio/vector.git?rev=01ea5d1db9e35aa951059cbcac8d172f5d67acd3#01ea5d1db9e35aa951059cbcac8d172f5d67acd3"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1294,7 +1294,7 @@ checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 [[package]]
 name = "fakedata"
 version = "0.1.0"
-source = "git+https://github.com/timberio/vector.git#01ea5d1db9e35aa951059cbcac8d172f5d67acd3"
+source = "git+https://github.com/timberio/vector.git?rev=01ea5d1db9e35aa951059cbcac8d172f5d67acd3#01ea5d1db9e35aa951059cbcac8d172f5d67acd3"
 dependencies = [
  "chrono",
  "fakedata_generator",
@@ -1330,7 +1330,7 @@ dependencies = [
 [[package]]
 name = "file-source"
 version = "0.1.0"
-source = "git+https://github.com/timberio/vector.git#01ea5d1db9e35aa951059cbcac8d172f5d67acd3"
+source = "git+https://github.com/timberio/vector.git?rev=01ea5d1db9e35aa951059cbcac8d172f5d67acd3#01ea5d1db9e35aa951059cbcac8d172f5d67acd3"
 dependencies = [
  "bstr",
  "bytes 1.0.1",
@@ -2901,6 +2901,7 @@ dependencies = [
  "metrics",
  "prost",
  "prost-types",
+ "regex",
  "rustls 0.19.0",
  "serde",
  "serde_json",
@@ -3414,7 +3415,7 @@ dependencies = [
 [[package]]
 name = "portpicker"
 version = "1.0.0"
-source = "git+https://github.com/timberio/vector.git#01ea5d1db9e35aa951059cbcac8d172f5d67acd3"
+source = "git+https://github.com/timberio/vector.git?rev=01ea5d1db9e35aa951059cbcac8d172f5d67acd3#01ea5d1db9e35aa951059cbcac8d172f5d67acd3"
 dependencies = [
  "rand 0.8.3",
 ]
@@ -3531,7 +3532,7 @@ dependencies = [
 [[package]]
 name = "prometheus-parser"
 version = "0.1.0"
-source = "git+https://github.com/timberio/vector.git#01ea5d1db9e35aa951059cbcac8d172f5d67acd3"
+source = "git+https://github.com/timberio/vector.git?rev=01ea5d1db9e35aa951059cbcac8d172f5d67acd3#01ea5d1db9e35aa951059cbcac8d172f5d67acd3"
 dependencies = [
  "indexmap",
  "nom",
@@ -4605,7 +4606,7 @@ dependencies = [
 [[package]]
 name = "shared"
 version = "0.1.0"
-source = "git+https://github.com/timberio/vector.git#01ea5d1db9e35aa951059cbcac8d172f5d67acd3"
+source = "git+https://github.com/timberio/vector.git?rev=01ea5d1db9e35aa951059cbcac8d172f5d67acd3#01ea5d1db9e35aa951059cbcac8d172f5d67acd3"
 dependencies = [
  "bytes 1.0.1",
  "chrono",
@@ -5430,7 +5431,7 @@ dependencies = [
 [[package]]
 name = "tracing-limit"
 version = "0.1.0"
-source = "git+https://github.com/timberio/vector.git#01ea5d1db9e35aa951059cbcac8d172f5d67acd3"
+source = "git+https://github.com/timberio/vector.git?rev=01ea5d1db9e35aa951059cbcac8d172f5d67acd3#01ea5d1db9e35aa951059cbcac8d172f5d67acd3"
 dependencies = [
  "ansi_term 0.12.1",
  "dashmap",
@@ -5737,7 +5738,7 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 [[package]]
 name = "vector"
 version = "0.13.0"
-source = "git+https://github.com/timberio/vector.git#01ea5d1db9e35aa951059cbcac8d172f5d67acd3"
+source = "git+https://github.com/timberio/vector.git?rev=01ea5d1db9e35aa951059cbcac8d172f5d67acd3#01ea5d1db9e35aa951059cbcac8d172f5d67acd3"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -5880,7 +5881,7 @@ checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 [[package]]
 name = "vrl"
 version = "0.1.0"
-source = "git+https://github.com/timberio/vector.git#01ea5d1db9e35aa951059cbcac8d172f5d67acd3"
+source = "git+https://github.com/timberio/vector.git?rev=01ea5d1db9e35aa951059cbcac8d172f5d67acd3#01ea5d1db9e35aa951059cbcac8d172f5d67acd3"
 dependencies = [
  "bytes 1.0.1",
  "indoc",
@@ -5894,7 +5895,7 @@ dependencies = [
 [[package]]
 name = "vrl-compiler"
 version = "0.1.0"
-source = "git+https://github.com/timberio/vector.git#01ea5d1db9e35aa951059cbcac8d172f5d67acd3"
+source = "git+https://github.com/timberio/vector.git?rev=01ea5d1db9e35aa951059cbcac8d172f5d67acd3#01ea5d1db9e35aa951059cbcac8d172f5d67acd3"
 dependencies = [
  "bitflags",
  "bytes 1.0.1",
@@ -5914,7 +5915,7 @@ dependencies = [
 [[package]]
 name = "vrl-diagnostic"
 version = "0.1.0"
-source = "git+https://github.com/timberio/vector.git#01ea5d1db9e35aa951059cbcac8d172f5d67acd3"
+source = "git+https://github.com/timberio/vector.git?rev=01ea5d1db9e35aa951059cbcac8d172f5d67acd3#01ea5d1db9e35aa951059cbcac8d172f5d67acd3"
 dependencies = [
  "codespan-reporting",
  "termcolor",
@@ -5923,7 +5924,7 @@ dependencies = [
 [[package]]
 name = "vrl-parser"
 version = "0.1.0"
-source = "git+https://github.com/timberio/vector.git#01ea5d1db9e35aa951059cbcac8d172f5d67acd3"
+source = "git+https://github.com/timberio/vector.git?rev=01ea5d1db9e35aa951059cbcac8d172f5d67acd3#01ea5d1db9e35aa951059cbcac8d172f5d67acd3"
 dependencies = [
  "lalrpop",
  "lalrpop-util",
@@ -5936,7 +5937,7 @@ dependencies = [
 [[package]]
 name = "vrl-stdlib"
 version = "0.1.0"
-source = "git+https://github.com/timberio/vector.git#01ea5d1db9e35aa951059cbcac8d172f5d67acd3"
+source = "git+https://github.com/timberio/vector.git?rev=01ea5d1db9e35aa951059cbcac8d172f5d67acd3#01ea5d1db9e35aa951059cbcac8d172f5d67acd3"
 dependencies = [
  "base64 0.13.0",
  "bytes 1.0.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,10 +33,11 @@ metrics = { version = "0.14", default-features = false }
 tokio-stream = { version = "0.1.5", default-features = false, features = ["net", "sync"] }
 hyper = { version = "0.14", default-features = false, features = ["stream"] }
 hyper-openssl = { version = "0.9.1", default-features = false, features = ["tcp"] }
+regex = "1"
 
 [dependencies.vector]
 git = "https://github.com/timberio/vector.git"
-ref = "01ea5d1db9e35aa951059cbcac8d172f5d67acd3"
+rev = "01ea5d1db9e35aa951059cbcac8d172f5d67acd3"
 default-features = false
 features = [ "sources", "sinks", "transforms", "unix" ]
 

--- a/src/vector/sources/disks/disk_queue_length.rs
+++ b/src/vector/sources/disks/disk_queue_length.rs
@@ -1,0 +1,194 @@
+/// A source that scraps `proc/diskstats` to extract the disk queue length.
+/// Source: https://tipstricks.itmatrix.eu/procdiskstats-line-format
+use futures::{FutureExt, SinkExt, StreamExt};
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+use tokio_stream::wrappers::IntervalStream;
+use vector::internal_events::InternalEvent;
+use vector::{
+    config::{self, SourceConfig, SourceContext, SourceDescription},
+    event::{Metric, MetricKind, MetricValue},
+    Event,
+};
+
+struct ParsingError(Box<dyn std::error::Error + Send + 'static>);
+
+impl InternalEvent for ParsingError {
+    fn emit_logs(&self) {
+        error!(message = "Parsing error.", error = ?self.0);
+    }
+
+    fn emit_metrics(&self) {
+        metrics::counter!("parse_error_total", 1);
+    }
+}
+
+struct DiskNotFound;
+
+impl InternalEvent for DiskNotFound {
+    fn emit_logs(&self) {
+        error!("No disk matching the regex rules found");
+    }
+
+    fn emit_metrics(&self) {
+        metrics::counter!("disk_not_found", 1);
+    }
+}
+
+struct FileSystemError(std::io::Error);
+
+impl InternalEvent for FileSystemError {
+    fn emit_logs(&self) {
+        error!(message = "Filesystem error.", error = ?self.0);
+    }
+
+    fn emit_metrics(&self) {
+        metrics::counter!("filesystem_error", 1);
+    }
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug, Default)]
+pub struct DiskQueueLengthConfig {
+    #[serde(default = "default_scrape_interval_secs")]
+    scrape_interval_secs: u64,
+
+    #[serde(default)]
+    regexes: Vec<String>,
+
+    #[serde(default)]
+    namespace: String,
+}
+
+pub fn default_scrape_interval_secs() -> u64 {
+    3
+}
+
+inventory::submit! {
+    SourceDescription::new::<DiskQueueLengthConfig>("disk_queue_length")
+}
+
+vector::impl_generate_config_from_default!(DiskQueueLengthConfig);
+
+#[async_trait::async_trait]
+#[typetag::serde(name = "disk_queue_length")]
+impl SourceConfig for DiskQueueLengthConfig {
+    async fn build(&self, cx: SourceContext) -> crate::Result<vector::sources::Source> {
+        let mut out = cx
+            .out
+            .sink_map_err(|error| error!(message = "Error sending metric.", %error));
+        let mut ticks = IntervalStream::new(tokio::time::interval(Duration::from_secs(
+            self.scrape_interval_secs,
+        )))
+        .take_until(cx.shutdown);
+
+        // let disk_name = self.disk_name.clone();
+        let mut disk_regexes = Vec::new();
+
+        for regex in self.regexes.iter() {
+            disk_regexes.push(regex::Regex::new(regex.as_str())?);
+        }
+
+        let namespace = if self.namespace.is_empty() {
+            None
+        } else {
+            Some(self.namespace.clone())
+        };
+
+        Ok(Box::pin(
+            async move {
+                while ticks.next().await.is_some() {
+                    match tokio::fs::read("/proc/diskstats").await {
+                        Err(e) => {
+                            vector::emit!(FileSystemError(e));
+                            continue;
+                        }
+
+                        Ok(content) => match String::from_utf8(content) {
+                            Err(e) => {
+                                vector::emit!(ParsingError(Box::new(e)));
+                                continue;
+                            }
+
+                            Ok(content) => {
+                                let mut metric = None;
+
+                                for line in content.lines() {
+                                    let mut index = 0usize;
+                                    for column in line.split_whitespace() {
+                                        if index == 2 {
+                                            if !disk_regexes
+                                                .iter()
+                                                .any(|regex| regex.is_match(column))
+                                            {
+                                                break;
+                                            }
+                                        }
+
+                                        // Position of the disk queue length value.
+                                        if index == 11 {
+                                            match column.parse::<usize>() {
+                                                Err(e) => {
+                                                    vector::emit!(ParsingError(Box::new(e)));
+                                                    break;
+                                                }
+
+                                                Ok(value) => {
+                                                    let mut tags =
+                                                        std::collections::BTreeMap::new();
+
+                                                    tags.insert(
+                                                        "disk".to_string(),
+                                                        column.to_string(),
+                                                    );
+
+                                                    metric = Some(
+                                                        Metric::new(
+                                                            "disk_queue_length",
+                                                            MetricKind::Absolute,
+                                                            MetricValue::Gauge {
+                                                                value: value as f64,
+                                                            },
+                                                        )
+                                                        .with_namespace(namespace.clone())
+                                                        .with_tags(Some(tags))
+                                                        .with_timestamp(Some(chrono::Utc::now())),
+                                                    );
+                                                }
+                                            }
+
+                                            break;
+                                        }
+
+                                        index += 1;
+                                    }
+
+                                    if metric.is_some() {
+                                        break;
+                                    }
+                                }
+
+                                if let Some(metric) = metric {
+                                    if out.send(Event::Metric(metric)).await.is_err() {
+                                        break;
+                                    }
+                                } else {
+                                    vector::emit!(DiskNotFound);
+                                }
+                            }
+                        },
+                    }
+                }
+            }
+            .map(Ok)
+            .boxed(),
+        ))
+    }
+
+    fn output_type(&self) -> config::DataType {
+        config::DataType::Metric
+    }
+
+    fn source_type(&self) -> &'static str {
+        "disk_queue_length"
+    }
+}

--- a/src/vector/sources/disks/mod.rs
+++ b/src/vector/sources/disks/mod.rs
@@ -1,0 +1,1 @@
+pub mod disk_queue_length;

--- a/src/vector/sources/mod.rs
+++ b/src/vector/sources/mod.rs
@@ -1,1 +1,2 @@
+pub mod disks;
 pub mod eventstoredb;


### PR DESCRIPTION
That source reads `/proc/diskstats` continuously (by default, every 3secs)

Vector configuration file I used:

```toml
data_dir = "/var/lib/vector"

[sources.disk_queue_length]
    type = "disk_queue_length"
    namespace = "test_disk"
    disk_name = "nvme0n1" # adapt to your disk accordingly.

[sinks.console]
    inputs = ["disk_queue_length"]
    type = "console"
    target = "stdout"
    encoding.codec = "text"
```

**UPDATED - featuring the regex patch**

```toml
data_dir = "/var/lib/vector"

[sources.disk_queue_length]
    type = "disk_queue_length"
    namespace = "test_disk"
    regexes = ["{valid_regex}"]

[sinks.console]
    inputs = ["disk_queue_length"]
    type = "console"
    target = "stdout"
    encoding.codec = "text"
```