### PR TITLE
fix tags in disk-queue-length, adds driver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2906,6 +2906,7 @@ dependencies = [
  "serde",
  "serde_json",
  "structopt",
+ "tempfile",
  "tokio",
  "tokio-stream",
  "toml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5319,9 +5319,9 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f715efe02c0862926eb463e49368d38ddb119383475686178e32e26d15d06a66"
+checksum = "bf0aa6dfc29148c3826708dabbfa83c121eeb84df4d1468220825e3a33651687"
 dependencies = [
  "futures-core",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,3 +48,7 @@ path = "src/lib.rs"
 [[bin]]
 name = "nexus"
 path = "src/cli/nexus.rs"
+
+[[bin]]
+name = "show-disk-queue-length"
+path = "src/cli/show-disk-queue-length.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,9 @@ hyper = { version = "0.14", default-features = false, features = ["stream"] }
 hyper-openssl = { version = "0.9.1", default-features = false, features = ["tcp"] }
 regex = "1"
 
+[dev-dependencies]
+tempfile = "3.2.0"
+
 [dependencies.vector]
 git = "https://github.com/timberio/vector.git"
 rev = "01ea5d1db9e35aa951059cbcac8d172f5d67acd3"

--- a/src/cli/show-disk-queue-length.rs
+++ b/src/cli/show-disk-queue-length.rs
@@ -19,7 +19,7 @@ async fn main() {
         println!("Couldn't find any disks with the given regexes");
     } else {
         for r in results {
-            println!("{} {}", r.column, r.value);
+            println!("{} {}", r.disk, r.value);
         }
     }
 }

--- a/src/cli/show-disk-queue-length.rs
+++ b/src/cli/show-disk-queue-length.rs
@@ -1,0 +1,25 @@
+use nexus::vector::sources::disks::disk_queue_length;
+use structopt::StructOpt;
+
+#[derive(StructOpt, Debug)]
+#[structopt(name = "show-disk-queue-length", about = "Shows the disk queue length")]
+struct Opt {
+    disk_regexes: Vec<String>,
+}
+
+#[tokio::main]
+async fn main() {
+    let args = Opt::from_args();
+    let mut disk_regexes = Vec::new();
+    for regex in args.disk_regexes.iter() {
+        disk_regexes.push(regex::Regex::new(regex.as_str()).expect("error constructing regex"));
+    }
+    let results = disk_queue_length::get_disk_queue_length("/proc/diskstats", &disk_regexes).await;
+    if results.len() < 1 {
+        println!("Couldn't find any disks with the given regexes");
+    } else {
+        for r in results {
+            println!("{} {}", r.column, r.value);
+        }
+    }
+}

--- a/src/vector/sources/disks/disk_queue_length.rs
+++ b/src/vector/sources/disks/disk_queue_length.rs
@@ -120,45 +120,104 @@ pub async fn get_disk_queue_length(
 #[tokio::main]
 #[test]
 async fn test_get_disk_queue_length() {
-    let mut file = tempfile::NamedTempFile::new().expect("couldn't make temp file");
-    let diskstats = r#"
+    struct Test {
+        pub diskstats: &'static str,
+        pub expected_results: Vec<DiskQueueLengthResult>,
+    }
+
+    let tests = vec![
+        Test {
+            diskstats: r#"
    1       0 loop0 0 0 0  0  0 0  0  0   0 0 0 0 0 0 0
    1       1 loop1 0 0 0  0  0 0  0  0   0 0 0 0 0 0 0
    1       2 loop2 0 0 0  0  0 0  0  0   0 0 0 0 0 0 0   
    2       0 sda   1 0 4  8  9 0 13 14   2 1 2 0 0 0 0
    3       2 sda1  2 0 5 10 12 0 15  1   1 2 2 0 0 0 0
    4       3 sda2  3 0 6  7  0 0  0  0   0 1 2 0 0 0 0
-     "#;
-    let r = std::io::Write::write(&mut file, diskstats.as_bytes());
-    std::io::Write::flush(&mut file).expect("flush failed");
-    let count = r.unwrap();
-    assert_eq!(diskstats.len(), count);
-    let file_path = file
-        .path()
-        .to_str()
-        .expect("temp file not a string")
-        .to_string();
+     "#,
+            expected_results: vec![
+                DiskQueueLengthResult {
+                    disk: "sda".to_string(),
+                    value: 2.0,
+                },
+                DiskQueueLengthResult {
+                    disk: "sda1".to_string(),
+                    value: 1.0,
+                },
+                DiskQueueLengthResult {
+                    disk: "sda2".to_string(),
+                    value: 0.0,
+                },
+            ],
+        },
+        Test {
+            diskstats: r#"
+     "#,
+            expected_results: vec![],
+        },
+        Test {
+            diskstats: r#"
+   1       0 loop0 0 0 0  0  0 0  0  0   0 0 0 0 0 0 0
+   1       1 loop1 0 0 0  0  0 0  0  0   0 0 0 0 0 0 0
+   1       2 loop2 0 0 0  0  0 0  0  0   0 0 0 0 0 0 0   
+   2       0 sda   1 0 4  8  9 0 13 14   2 1 2 0 0 0 0
+   3       2 sda1  2 0 5 10 12 0 15  1   1 2 2 0 0 0 0
+   4       3 sda2  3 0 6  7  0 0  0  0 4.5 1 2 0 0 0 0
+     "#,
+            expected_results: vec![
+                DiskQueueLengthResult {
+                    disk: "sda".to_string(),
+                    value: 2.0,
+                },
+                DiskQueueLengthResult {
+                    disk: "sda1".to_string(),
+                    value: 1.0,
+                },
+            ],
+        },
+        Test {
+            diskstats: r#"
+   1       0 loop0 0 0 0  0  0 0  0  0   0 0 0 0 0 0 0
+   1       1 loop1 0 0 0  0  0 0  0  0   0 0 0 0 0 0 0
+   1       2 loop2 0 0 0  0  0 0  0  0   0 0 0 0 0 0 0   
+   2       0 sda   1 0 4  8 
+   3       2 sda1  2 0 5 10 12 0 15  1   1 2 2 0 0 0 0
+   4  
+   5       3 sda2  
+     "#,
+            expected_results: vec![DiskQueueLengthResult {
+                disk: "sda1".to_string(),
+                value: 1.0,
+            }],
+        },
+    ];
+
+    for test in tests {
+        let mut file = tempfile::NamedTempFile::new().expect("couldn't make temp file");
+        let r = std::io::Write::write(&mut file, test.diskstats.as_bytes());
+        std::io::Write::flush(&mut file).expect("flush failed");
+        let count = r.unwrap();
+        assert_eq!(test.diskstats.len(), count);
+        let file_path = file
+            .path()
+            .to_str()
+            .expect("temp file not a string")
+            .to_string();
+        let disk_regexes: Vec<regex::Regex> =
+            vec![regex::Regex::new("sda").expect("failure to make simple regex")];
+        let results = get_disk_queue_length(&file_path, &disk_regexes).await;
+        assert_eq!(test.expected_results, results);
+    }
+}
+
+#[tokio::main]
+#[test]
+async fn test_get_disk_queue_length_with_missing() {
     let disk_regexes: Vec<regex::Regex> =
         vec![regex::Regex::new("sda").expect("failure to make simple regex")];
-    println!("file_path = {}", file_path);
-    let result = get_disk_queue_length(&file_path, &disk_regexes).await;
-    assert_eq!(
-        vec![
-            DiskQueueLengthResult {
-                disk: "sda".to_string(),
-                value: 2.0
-            },
-            DiskQueueLengthResult {
-                disk: "sda1".to_string(),
-                value: 1.0
-            },
-            DiskQueueLengthResult {
-                disk: "sda2".to_string(),
-                value: 0.0
-            }
-        ],
-        result
-    );
+    // NOTE: test will fail if the file "jdfsuhvdshfvioushdfdsj" is present
+    let result = get_disk_queue_length("jdfsuhvdshfvioushdfdsj", &disk_regexes).await;
+    assert_eq!(Vec::<DiskQueueLengthResult>::new(), result);
 }
 
 #[async_trait::async_trait]

--- a/src/vector/sources/disks/disk_queue_length.rs
+++ b/src/vector/sources/disks/disk_queue_length.rs
@@ -149,6 +149,7 @@ impl SourceConfig for DiskQueueLengthConfig {
                     if results.len() < 1 {
                         vector::emit!(DiskNotFound);
                     } else {
+                        let timestamp = chrono::Utc::now();
                         for r in results {
                             let mut tags = std::collections::BTreeMap::new();
 
@@ -160,7 +161,7 @@ impl SourceConfig for DiskQueueLengthConfig {
                             )
                             .with_namespace(namespace.clone())
                             .with_tags(Some(tags))
-                            .with_timestamp(Some(chrono::Utc::now()));
+                            .with_timestamp(Some(timestamp));
                             if out.send(Event::Metric(metric)).await.is_err() {
                                 break;
                             }


### PR DESCRIPTION
Currently the disk_queue_length source is tagging metrics with a
a key called "disk" which contains the same value as the metric
itself due to a small issue.

This also extracts the function behind disk queue length to make it
callable from another binary. Maybe it's overkill; I found it useful so I
figured I'd commit it.