### PR TITLE
pins CLI tools used in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,8 @@ jobs:
       - name: Install Rust
         run: |
           rustup default stable
-          cargo install just
-          cargo install taplo-cli
+          cargo install just --version 1.1.2
+          cargo install taplo-cli --version 0.5.0
 
       - name: Build and Test
         run: |


### PR DESCRIPTION
The latest version of Taplo is rightfully using new Rust features,  but
this causes our builds to fail as we're on an older Rust version. This
just pins the versions of taplo and just pulled down by CI.