### PR TITLE
Implement out of sync cluster detection.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2835,7 +2835,6 @@ dependencies = [
  "inventory 0.1.11",
  "metrics 0.16.0",
  "num_cpus",
- "rand 0.7.3",
  "regex",
  "serde",
  "serde_json",
@@ -3689,7 +3688,6 @@ dependencies = [
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc 0.2.0",
- "rand_pcg",
 ]
 
 [[package]]
@@ -3768,15 +3766,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
 dependencies = [
  "rand_core 0.6.3",
-]
-
-[[package]]
-name = "rand_pcg"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
-dependencies = [
- "rand_core 0.5.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ hyper-openssl = { version = "0.9.1", default-features = false, features = [
 inventory = "0.1.10"
 metrics = { version = "0.16.0", default-features = false, features = ['std'] }
 num_cpus = "1.13.0"
-rand = { version = "*", features = ["small_rng"] }
 regex = "1.5.4"
 serde = { version = "1.0.117", features = ["derive"] }
 serde_json = { version = "1.0.64", features = ["raw_value"] }


### PR DESCRIPTION
* renames `dead_nodes` to `unresponsive_nodes`
* improves multi-leaders detection.
* implements out-of-sync cluster detection.
* exposes leader epoch number and writer checkpoint.
* renames `default_scrape_interval_secs` setting to `default_frequency_secs`.